### PR TITLE
Solution of challenge-1.md

### DIFF
--- a/challenge-1.md
+++ b/challenge-1.md
@@ -1,19 +1,37 @@
-# Data Packet Corruption Detection
-* In a Wireless communciation device, multiple data packets are transferred over the air. 
-* It is possible that data might get corrupted or lost before it reaches the destination.
-* Create a method to identify if a data packet is corrupted
-* Assume below format for the data packet
+#include <stdint.h>
 
-```
 #define MAX_PACKET_DATA_LENGTH (50)
 
-typedef struct data_packet_t{
+typedef struct data_packet_t {
     uint8_t id;
     uint8_t data_length;
     uint8_t data[MAX_PACKET_DATA_LENGTH];
     uint16_t crc;
-}data_packet_t;
+} data_packet_t;
 
-```
-# FAQ's
-* Links to Discussions
+// Function to calculate the CRC
+uint16_t calculateCRC(const uint8_t* data, size_t length) {
+    uint16_t crc = 0xFFFF; // Initial CRC value
+
+    for (size_t i = 0; i < length; i++) {
+        crc ^= data[i];
+
+        for (int j = 0; j < 8; j++) {
+            if (crc & 0x0001) {
+                crc >>= 1;
+                crc ^= 0xA001; // CRC-16 polynomial
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+
+    return crc;
+}
+
+// Function to check if a data packet is corrupted
+int isPacketCorrupted(const data_packet_t* packet) {
+    uint16_t calculatedCRC = calculateCRC(packet->data, packet->data_length);
+
+    return (calculatedCRC != packet->crc);
+}


### PR DESCRIPTION
The isPacketCorrupted function takes a pointer to a data_packet_t structure as input. It calculates the CRC for the data in the packet using the calculateCRC function and compares it with the CRC value stored in the packet. If the calculated CRC does not match the stored CRC, it indicates that the data packet is corrupted.